### PR TITLE
WIP: add support for iOS MagicTap

### DIFF
--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -961,6 +961,9 @@ class RenderCustomPaint extends RenderProxyBox {
     if (properties.onDismiss != null) {
       config.onDismiss = properties.onDismiss;
     }
+    if (properties.onDefaultAction != null) {
+      config.onDefaultAction = properties.onDefaultAction;
+    }
 
     newChild.updateWith(
       config: config,

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3595,6 +3595,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     SemanticsSortKey sortKey,
     VoidCallback onTap,
     VoidCallback onDismiss,
+    VoidCallback onDefaultAction,
     VoidCallback onLongPress,
     VoidCallback onScrollLeft,
     VoidCallback onScrollRight,
@@ -3639,6 +3640,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
        _hidden = hidden,
        _image = image,
        _onDismiss = onDismiss,
+       _onDefaultAction = onDefaultAction,
        _label = label,
        _value = value,
        _increasedValue = increasedValue,
@@ -4078,6 +4080,27 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       return;
     final bool hadValue = _onDismiss != null;
     _onDismiss = handler;
+    if ((handler != null) == hadValue)
+      markNeedsSemanticsUpdate();
+  }
+
+  /// The handler for [SemanticsAction.defaultAction].
+  ///
+  /// This is a request to perform a default action for the node,
+  /// which typically toggles the most important state on the node.
+  ///
+  /// VoiceOver users on iOS can perform a double two-finger tap (MagicTap)
+  /// to send this request.
+  ///
+  /// As examples, in the Phone app it answers and ends calls,
+  /// in the Music app it starts and pauses playback.
+  VoidCallback get onDefaultAction => _onDefaultAction;
+  VoidCallback _onDefaultAction;
+  set onDefaultAction(VoidCallback handler) {
+    if (_onDefaultAction == handler)
+      return;
+    final bool hadValue = _onDefaultAction != null;
+    _onDefaultAction = handler;
     if ((handler != null) == hadValue)
       markNeedsSemanticsUpdate();
   }
@@ -4529,6 +4552,8 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       config.onLongPress = _performLongPress;
     if (onDismiss != null)
       config.onDismiss = _performDismiss;
+    if (onDefaultAction != null)
+      config.onDefaultAction = _performDefaultAction;
     if (onScrollLeft != null)
       config.onScrollLeft = _performScrollLeft;
     if (onScrollRight != null)
@@ -4578,6 +4603,11 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   void _performDismiss() {
     if (onDismiss != null)
       onDismiss();
+  }
+
+  void _performDefaultAction() {
+    if (onDefaultAction != null)
+      onDefaultAction();
   }
 
   void _performScrollLeft() {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -632,6 +632,7 @@ class SemanticsProperties extends DiagnosticableTree {
     this.onDidGainAccessibilityFocus,
     this.onDidLoseAccessibilityFocus,
     this.onDismiss,
+    this.onDefaultAction,
     this.customSemanticsActions,
   });
 
@@ -1123,6 +1124,18 @@ class SemanticsProperties extends DiagnosticableTree {
   /// menu, and VoiceOver users on iOS can trigger this action with a standard
   /// gesture or menu option.
   final VoidCallback onDismiss;
+
+  /// The handler for [SemanticsAction.defaultAction].
+  ///
+  /// This is a request to perform a default action for the node,
+  /// which typically toggles the most important state on the node.
+  ///
+  /// VoiceOver users on iOS can perform a double two-finger tap (MagicTap)
+  /// to send this request.
+  ///
+  /// As examples, in the Phone app it answers and ends calls,
+  /// in the Music app it starts and pauses playback.
+  final VoidCallback onDefaultAction;
 
   /// A map from each supported [CustomSemanticsAction] to a provided handler.
   ///
@@ -2918,6 +2931,23 @@ class SemanticsConfiguration {
   set onDismiss(VoidCallback value) {
     _addArgumentlessAction(SemanticsAction.dismiss, value);
     _onDismiss = value;
+  }
+
+  /// The handler for [SemanticsAction.defaultAction].
+  ///
+  /// This is a request to perform a default action for the node,
+  /// which typically toggles the most important state of the node.
+  ///
+  /// VoiceOver users on iOS can perform a double two-finger tap,
+  /// also known as a Magic Tap, to send this request.
+  ///
+  /// As examples, in the Phone app it answers and ends calls,
+  /// in the Music app it starts and pauses playback.
+  VoidCallback get onDefaultAction => _onDefaultAction;
+  VoidCallback _onDefaultAction;
+  set onDefaultAction(VoidCallback value) {
+    _addArgumentlessAction(SemanticsAction.defaultAction, value);
+    _onDefaultAction = value;
   }
 
   /// The handler for [SemanticsAction.scrollRight].

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6506,6 +6506,7 @@ class Semantics extends SingleChildRenderObjectWidget {
     VoidCallback onCut,
     VoidCallback onPaste,
     VoidCallback onDismiss,
+    VoidCallback onDefaultAction,
     MoveCursorHandler onMoveCursorForwardByCharacter,
     MoveCursorHandler onMoveCursorBackwardByCharacter,
     SetSelectionHandler onSetSelection,
@@ -6563,6 +6564,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       onDidGainAccessibilityFocus: onDidGainAccessibilityFocus,
       onDidLoseAccessibilityFocus: onDidLoseAccessibilityFocus,
       onDismiss: onDismiss,
+      onDefaultAction: onDefaultAction,
       onSetSelection: onSetSelection,
       customSemanticsActions: customSemanticsActions,
       hintOverrides: onTapHint != null || onLongPressHint != null ?
@@ -6672,6 +6674,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       onDecrease: properties.onDecrease,
       onCopy: properties.onCopy,
       onDismiss: properties.onDismiss,
+      onDefaultAction: properties.onDefaultAction,
       onCut: properties.onCut,
       onPaste: properties.onPaste,
       onMoveCursorForwardByCharacter: properties.onMoveCursorForwardByCharacter,
@@ -6740,6 +6743,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       ..onScrollDown = properties.onScrollDown
       ..onIncrease = properties.onIncrease
       ..onDismiss = properties.onDismiss
+      ..onDefaultAction = properties.onDefaultAction
       ..onDecrease = properties.onDecrease
       ..onCopy = properties.onCopy
       ..onCut = properties.onCut

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -606,6 +606,8 @@ void main() {
     expect(config.onIncrease, isNull);
     expect(config.onMoveCursorForwardByCharacter, isNull);
     expect(config.onMoveCursorBackwardByCharacter, isNull);
+    expect(config.onDismiss, isNull);
+    expect(config.onDefaultAction, isNull);
     expect(config.onTap, isNull);
     expect(config.customSemanticsActions[customAction], isNull);
 
@@ -630,6 +632,8 @@ void main() {
     final VoidCallback onIncrease = () { };
     final MoveCursorHandler onMoveCursorForwardByCharacter = (bool _) { };
     final MoveCursorHandler onMoveCursorBackwardByCharacter = (bool _) { };
+    final VoidCallback onDismiss = () { };
+    final VoidCallback onDefaultAction = () { };
     final VoidCallback onTap = () { };
     final VoidCallback onCustomAction = () { };
 
@@ -643,6 +647,8 @@ void main() {
     config.onIncrease = onIncrease;
     config.onMoveCursorForwardByCharacter = onMoveCursorForwardByCharacter;
     config.onMoveCursorBackwardByCharacter = onMoveCursorBackwardByCharacter;
+    config.onDismiss = onDismiss;
+    config.onDefaultAction = onDefaultAction;
     config.onTap = onTap;
     config.customSemanticsActions[customAction] = onCustomAction;
 
@@ -667,6 +673,8 @@ void main() {
     expect(config.onIncrease, same(onIncrease));
     expect(config.onMoveCursorForwardByCharacter, same(onMoveCursorForwardByCharacter));
     expect(config.onMoveCursorBackwardByCharacter, same(onMoveCursorBackwardByCharacter));
+    expect(config.onDismiss, same(onDismiss));
+    expect(config.onDefaultAction, same(onDefaultAction));
     expect(config.onTap, same(onTap));
     expect(config.customSemanticsActions[customAction], same(onCustomAction));
   });


### PR DESCRIPTION
## Description

Add support for iOS accessibility event MagicTap.

Implemented in the engine as `SemanticsAction.defaultAction` via https://github.com/flutter/engine/pull/17267 and activated on the iOS event [accessibilityPerformMagicTap](https://developer.apple.com/documentation/objectivec/nsobject/1615137-accessibilityperformmagictap).

## Related Issues

Fixes https://github.com/flutter/flutter/issues/3816
Depends on https://github.com/flutter/engine/pull/17267

## Questions to the Flutter Team
I'm new to the SDK and trying my best, but need some guidance here:
1. Why does the `Semantics` widget become focusable with VoiceOver whenever an action is added to it? Example: Semantics with props `container: false, onDismiss: () {}` is focusable as an outer node.
2. Why does it seem like `SemanticsAction.onDismiss` "bubbles" upwards in the semantics tree, but `onDefaultAction` which I implemented does not. E.g. wrapping the Scaffold in a Semantics node which handles `onDismiss` and `onDefaultAction` only works for `onDismiss`.
3. What is the best approach for defining an app-level or route-level magic-tap og dismiss handler? Normally this would be done via the AppDelegate, but in Flutter I guess it would be on the Scaffold or MaterialApp?

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
